### PR TITLE
Check KAFKA_START before JAVA_HOME

### DIFF
--- a/debian/kafka.init
+++ b/debian/kafka.init
@@ -107,14 +107,14 @@ kafka_sh() {
 
 case "$1" in
   start)
-	if [ -z "$JAVA_HOME" ]; then
-		log_failure_msg "no JDK found - please set JAVA_HOME"
-		exit 1
-	fi
-
 	if [ -n "$KAFKA_START" -a "$KAFKA_START" != "yes" ]; then
 		log_failure_msg "KAFKA_START not set to 'yes' in $DEFAULT, not starting"
 		exit 0
+	fi
+
+	if [ -z "$JAVA_HOME" ]; then
+		log_failure_msg "no JDK found - please set JAVA_HOME"
+		exit 1
 	fi
 
 	log_daemon_msg "Starting $DESC" "$NAME"


### PR DESCRIPTION
Currently, if Java hasn't yet been set up when this package is installed,
installation will fail when the init script checks for JAVA_HOME.

Instead, check for KAFKA_START first---it will be 'no' immediately upon
installation---and abort cleanly before failing to find Java.
