### PR TITLE
Depend on any java7 jre/jdk

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kafka
 Section: misc
 Priority: optional
 Maintainer: Alexandros Kosiaris <akosiaris@wikimedia.org>
-Build-Depends: debhelper (>= 9), openjdk-7-jdk, javahelper (>= 0.40),
+Build-Depends: debhelper (>= 9), java7-jdk, javahelper (>= 0.40),
  junit4,
  velocity,
  libasm3-java,
@@ -37,7 +37,7 @@ Homepage: http://kafka.apache.org
 
 Package: kafka
 Architecture: all
-Depends: openjdk-7-jre, scala-library, adduser, ${java:Depends}, ${misc:Depends}
+Depends: java7-runtime, scala-library, adduser, ${java:Depends}, ${misc:Depends}
 Recommends: ${java:Recommends}
 Description: Apache Kafka is a distributed publish-subscribe messaging system
  Apache Kafka is designed to support the following


### PR DESCRIPTION
openjdk-7-jdk and openjdk-7-jre provide java7-sdk and java7-runtime respectively. This change allows kafka to be built with any java 7 jre/jdk.
